### PR TITLE
feat: add backstage catalog, docs, and Dapr CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# dapr-workflows
+
+Dapr workflow orchestration for infrastructure automation — golden image builds, provisioning, and more.
+
+## Overview
+
+This repository contains Dapr durable workflows that orchestrate infrastructure automation tasks. Workflows run as Go services on Kubernetes with Dapr sidecar injection, calling [Dagger modules](https://github.com/stuttgart-things/blueprints) as building blocks.
+
+## Workflows
+
+| Workflow | Description | Status |
+|----------|-------------|--------|
+| golden-image-build | Render → packer build → test VM → promote golden image | Planned |
+
+## Getting Started
+
+### Install Dapr CLI
+
+```bash
+wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+dapr init
+```
+
+See [docs/setup/dapr-cli.md](docs/setup/dapr-cli.md) for details.
+
+## Author
+
+Patrick Hermann, stuttgart-things (2025-2026)
+
+## License
+
+Licensed under the Apache License 2.0.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: dapr-workflows
+  description: Dapr workflow orchestration for infrastructure automation (golden image builds, provisioning, etc.)
+  annotations:
+    github.com/project-slug: stuttgart-things/dapr-workflows
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/dapr-workflows/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/dapr-workflows
+  tags:
+    - dapr
+    - workflows
+    - golang
+    - automation
+    - dagger
+    - kubernetes
+  links:
+    - url: https://github.com/stuttgart-things/dapr-workflows
+      title: GitHub Repository
+      icon: github
+spec:
+  type: service
+  lifecycle: experimental
+  owner: platform-team
+  system: platform-engineering
+  dependsOn:
+    - resource:redis
+    - component:blueprints

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Dapr Workflows
+
+Dapr workflow orchestration for infrastructure automation — golden image builds, provisioning, and more.
+
+## Overview
+
+This repository contains Dapr durable workflows that orchestrate infrastructure automation tasks. Each workflow is a standalone Go service deployed on Kubernetes with Dapr sidecar injection.
+
+Workflows call existing [Dagger modules](https://github.com/stuttgart-things/blueprints) as building blocks via `dagger call` subprocess invocations, combining them into reliable, retryable pipelines with compensation logic.
+
+## Workflows
+
+| Workflow | Description | Status |
+|----------|-------------|--------|
+| golden-image-build | Render config, packer build, test VM, promote golden image | Planned |
+
+## Architecture
+
+```
+Cron (Dapr binding) or API trigger
+    ↓
+Dapr Workflow Engine (state persisted in Redis)
+    ↓
+Activities (each wraps a `dagger call` subprocess)
+    ↓
+Dagger Modules (blueprints: vmtemplate, vm, packer)
+```
+
+## Getting Started
+
+1. [Install the Dapr CLI](setup/dapr-cli.md)
+2. Scaffold and run your first workflow (coming soon)
+
+## Author
+
+Patrick Hermann, stuttgart-things (2025-2026)
+
+## License
+
+Licensed under the Apache License 2.0.

--- a/docs/setup/dapr-cli.md
+++ b/docs/setup/dapr-cli.md
@@ -1,0 +1,75 @@
+# Dapr CLI Setup
+
+## Prerequisites
+
+- Docker (for local development containers)
+- Go 1.24+
+
+## Install Dapr CLI
+
+```bash
+# Linux (amd64)
+wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+
+# macOS (Homebrew)
+brew install dapr/tap/dapr-cli
+```
+
+## Initialize Dapr Locally
+
+```bash
+dapr init
+```
+
+This starts the following Docker containers:
+
+| Container | Purpose |
+|-----------|---------|
+| `dapr_redis` | State store + pub/sub for workflows |
+| `dapr_zipkin` | Distributed tracing |
+| `dapr_placement` | Actor placement service |
+| `dapr_scheduler` | Scheduled job execution |
+
+## Verify Installation
+
+```bash
+dapr --version
+# CLI version: 1.17.0
+# Runtime version: 1.17.3
+
+docker ps --format "table {{.Names}}\t{{.Status}}"
+# dapr_redis       Up ...
+# dapr_zipkin      Up ...
+# dapr_placement   Up ...
+# dapr_scheduler   Up ...
+```
+
+## Default Components (Local)
+
+After `dapr init`, default component definitions are created at `~/.dapr/components/`:
+
+| File | Type | Backend |
+|------|------|---------|
+| `statestore.yaml` | state.redis | localhost:6379 |
+| `pubsub.yaml` | pubsub.redis | localhost:6379 |
+
+These are automatically loaded when running apps with `dapr run`.
+
+## Running a Dapr App Locally
+
+```bash
+dapr run --app-id myapp --app-port 8080 -- go run main.go
+```
+
+## Useful Commands
+
+```bash
+dapr list                    # List running Dapr apps
+dapr dashboard               # Open Dapr dashboard (localhost:8080)
+dapr stop --app-id myapp     # Stop a running app
+dapr uninstall               # Remove Dapr from local environment
+```
+
+## Next Steps
+
+Once Dapr is running locally, proceed to scaffold the golden-image-build workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Dapr Workflows
+site_description: Dapr workflow orchestration for infrastructure automation
+
+nav:
+  - Home: index.md
+  - Setup:
+    - Dapr CLI: setup/dapr-cli.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Add Backstage `catalog-info.yaml` (service, experimental, depends on redis + blueprints)
- Add `mkdocs.yml` for TechDocs integration
- Add `README.md` with project overview
- Add `docs/setup/dapr-cli.md` with Dapr CLI install, init, and verify instructions

## Test plan
- [ ] Verify catalog-info.yaml renders in Backstage
- [ ] Verify TechDocs builds from mkdocs.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)