### PR TITLE
feat: add repository linting workflow

### DIFF
--- a/.github/workflows/lint-repo.yaml
+++ b/.github/workflows/lint-repo.yaml
@@ -1,0 +1,27 @@
+---
+name: Run Repository Linting
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Lint-Repository:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-repository-linting.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      environment-name: linting
+      app-directory: "./"
+      output-file: "/tmp/dapr-workflows.txt"
+      continue-error: "true"
+      dagger-version: v0.20.0
+      dagger-module-version: v1.59.0
+      branch-name: ${{ github.head_ref || github.ref_name }}
+    secrets: inherit # pragma: allowlist secret

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,13 @@
+---
+version: 3
+includes:
+  git:
+    taskfile: https://raw.githubusercontent.com/stuttgart-things/tasks/refs/heads/main/git/git.yaml
+
+dotenv: ['.env', '{{.HOME}}/.env']
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list


### PR DESCRIPTION
## Summary
- Add `.github/workflows/lint-repo.yaml` calling the reusable `call-repository-linting` workflow
- Runs on push to main and PRs to main
- Uses Dagger v0.20.0 / module v1.59.0 (matching other repos)

## Test plan
- [ ] Verify linting runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)