### PR TITLE
feat: add ko build pipeline (GH Actions + Taskfile)

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -1,0 +1,26 @@
+---
+name: Build, Push & Scan Container Image
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "golden-image-workflow/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "golden-image-workflow/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      build-path: ./golden-image-workflow
+    secrets: inherit # pragma: allowlist secret

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,8 +6,49 @@ includes:
 
 dotenv: ['.env', '{{.HOME}}/.env']
 
+vars:
+  PROJECT: dapr-golden-packer-image-workflow
+  SOURCE_CODE_DIR: ./golden-image-workflow
+  DAGGER_GO_MODULE: github.com/stuttgart-things/dagger/go
+  DAGGER_TRIVY_MODULE: github.com/stuttgart-things/dagger/trivy
+  TARGET_IMAGE_REPO: ghcr.io/stuttgart-things/dapr-golden-packer-image-workflow
+
 tasks:
   default:
     desc: List available tasks
     cmds:
       - task --list
+
+  build-scan-image-ko:
+    desc: Build, push and scan container image with ko
+    cmds:
+      - |
+        RANDOM_TAG=$(openssl rand -hex 6)
+        REPO_NAME="ttl.sh/{{ .PROJECT }}-${RANDOM_TAG}"
+
+        echo "Building and pushing to: ${REPO_NAME}"
+
+        IMAGE_REF=$(dagger call -m {{ .DAGGER_GO_MODULE }} ko-build \
+          --src "{{ .SOURCE_CODE_DIR }}" \
+          --repo "$REPO_NAME" \
+          --push="true" \
+          --progress plain)
+
+        echo "Image pushed: $IMAGE_REF"
+        echo "Scanning with Trivy..."
+
+        dagger call -m {{ .DAGGER_TRIVY_MODULE }} scan-image \
+          --image-ref "$IMAGE_REF" \
+          --severity "HIGH,CRITICAL" \
+          --progress plain \
+          export --path=/tmp/trivy-scan-{{ .PROJECT }}.json
+
+        echo "Build and scan complete!"
+        echo "Image: $IMAGE_REF"
+        echo "Scan Report: /tmp/trivy-scan-{{ .PROJECT }}.json"
+
+        if command -v jq &> /dev/null; then
+          echo ""
+          jq -r '.Results[]? | select(.Vulnerabilities) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"' \
+            /tmp/trivy-scan-{{ .PROJECT }}.json 2>/dev/null || echo "No HIGH/CRITICAL vulnerabilities found!"
+        fi


### PR DESCRIPTION
## Summary
- Adds `build-scan-image.yaml` GH Actions workflow — triggers on push/PR to `golden-image-workflow/**`, calls reusable `call-ko-build.yaml` with `build-path: ./golden-image-workflow`
- Adds `build-scan-image-ko` Taskfile task — builds with ko via `stuttgart-things/dagger/go`, scans with `stuttgart-things/dagger/trivy`, no local dagger module needed
- Target registry: `ghcr.io/stuttgart-things/dapr-golden-packer-image-workflow`

## Test plan
- [ ] Verify GH Actions workflow triggers on next push to main
- [ ] Run `task build-scan-image-ko` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)