### PR TITLE
fix: set working-directory for ko build in mono-repo

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -22,5 +22,6 @@ jobs:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest
-      build-path: ./golden-image-workflow
+      working-directory: golden-image-workflow
+      build-path: .
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary
- Fixes `cannot find main module` error in CI ([run 23783874197](https://github.com/stuttgart-things/dapr-workflows/actions/runs/23783874197))
- `ko` must run from `golden-image-workflow/` where `go.mod` lives — uses new `working-directory` input from [github-workflow-templates#59](https://github.com/stuttgart-things/github-workflow-templates/pull/59)
- Resets `build-path` to `.` (relative to working-directory)

## Test plan
- [ ] CI workflow should pass on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)