### PR TITLE
fix: set go-version 1.26 for CI ko build

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -22,6 +22,7 @@ jobs:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest
+      go-version: "1.26"
       working-directory: golden-image-workflow
       build-path: .
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary
- Fixes CI build failure: `go.mod requires go >= 1.26.0 (running go 1.25.5)`
- Also fixed in upstream template: cache-dependency-path for mono-repo ([github-workflow-templates#60](https://github.com/stuttgart-things/github-workflow-templates/pull/60))

## Test plan
- [ ] CI workflow should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)