### PR TITLE
feat(golden-image-workflow): add VsphereTemplateWorkflow with resilient dispatch

### DIFF
--- a/golden-image-workflow/README.md
+++ b/golden-image-workflow/README.md
@@ -47,11 +47,72 @@ dapr run --app-id golden-image -- ./golden-image-workflow --run --input examples
 
 | File | Description |
 |------|-------------|
-| `examples/inputs/ubuntu24-labul.json` | Ubuntu 24 on labul |
-| `examples/inputs/ubuntu24-labda.json` | Ubuntu 24 on labda |
-| `examples/inputs/rocky9-labul.json` | Rocky 9 on labul |
+| `examples/inputs/ubuntu24-labul.json` | Ubuntu 24 on labul (full pipeline) |
+| `examples/inputs/ubuntu24-labda.json` | Ubuntu 24 on labda (full pipeline) |
+| `examples/inputs/rocky9-labul.json` | Rocky 9 on labul (full pipeline) |
+| `examples/inputs/vsphere-ubuntu26-labda.json` | Ubuntu 26 on labda (build + promote only) |
+| `examples/inputs/vsphere-rocky9-labul.json` | Rocky 9 on labul (build + promote only) |
+| `examples/inputs/vsphere-ubuntu26-labda-resume.json` | Resume mode: skip build, promote an existing template |
 
 The GitHub token is read from the `GITHUB_TOKEN` environment variable (not stored in JSON).
+
+### Workflows
+
+Two workflows are registered:
+
+| Name | Steps | Use when |
+|------|-------|----------|
+| `GoldenImageBuildWorkflow` (default) | render → build → (test) → (promote) → (notify) | You want the full pipeline from source rendering through notification |
+| `VsphereTemplateWorkflow` | build → promote | Packer config is already committed; you just want to build and promote to golden |
+
+Select the lean workflow with `--workflow`:
+
+```bash
+dapr run --app-id golden-image -- ./golden-image-workflow \
+  --run --workflow VsphereTemplateWorkflow \
+  --input examples/inputs/vsphere-ubuntu26-labda.json
+```
+
+`VsphereTemplateWorkflow` exposes the HTTP endpoint `/start-vsphere-template`:
+
+```bash
+curl -X POST http://localhost:8080/start-vsphere-template \
+  -H "Content-Type: application/json" \
+  -d @examples/inputs/vsphere-ubuntu26-labda.json
+```
+
+#### Template name handoff
+
+The input JSON only carries the **target** golden image name (`promotion.targetName`, e.g. `sthings-u26`). The **source** template name — Packer's timestamped build artifact like `ubuntu26-base-20260423-1124` — doesn't exist yet at dispatch time. It flows between jobs at runtime:
+
+1. The Packer build GH Actions workflow constructs the name (`<os>-<provisioning>-<YYYYMMDD-hhmm>`) and echoes `Template name: <value>` to the run log.
+2. `PackerBuildActivity` fetches the run log after completion and extracts the value via `ExtractFromLog` (last match wins, to skip the shell-source line).
+3. Dapr persists it as workflow state — if the worker crashes between build and promote, the resumed worker still has the name.
+4. `PromoteActivity` passes it as the `template-name` input to `dispatch-packer-movetemplate.yaml`, which uses it as the rename source.
+
+The workflow fails fast with `FailedStep: "PackerBuild"` if extraction returns empty, so a malformed log can't silently cascade into a broken rename.
+
+#### Resilience: retries, adoption, and manual resume
+
+Three safety nets prevent lost work when something goes wrong between "dispatch the build" and "promote the result":
+
+1. **Dispatch retry.** `DispatchWorkflow` retries transient network errors and HTTP 5xx responses up to 3 times with exponential backoff (5s → 10s → 20s). 4xx responses (bad ref, missing inputs) are returned immediately — they won't resolve on retry.
+
+2. **Dispatch adoption.** GitHub's dispatch endpoint is not strictly transactional — a 5xx response can still mean the run was queued. `DispatchAndFindRun` always polls for a recently-created run after dispatching, even when dispatch errored. If GH queued the run despite the error, the activity adopts it instead of giving up. This eliminates a whole class of orphan runs that previously accumulated in GH while Dapr had forgotten about them.
+
+3. **Activity retry policy.** Both the Packer build and the Promote activities are wrapped in durable retry policies:
+   - Packer build: 2 attempts, 30s initial backoff, 5m total timeout. Conservative to avoid kicking off a second long-running build.
+   - Promote: 3 attempts, 10s initial backoff, 10m total timeout. Safe to retry — the promote workflow's `continue-on-error` on the delete step handles pre-existing templates.
+
+4. **Manual resume mode.** For the case where a previous Dapr run terminated after GH had already started the Packer build (so a template exists in vCenter but Dapr has no memory of it), set `existingTemplateName` in the input JSON:
+
+   ```json
+   "existingTemplateName": "ubuntu26-base-os-20260423-1428"
+   ```
+
+   When set, the workflow skips the Packer build step entirely and jumps straight to promote with the given template name. See [examples/inputs/vsphere-ubuntu26-labda-resume.json](examples/inputs/vsphere-ubuntu26-labda-resume.json).
+
+   Use case: Dapr terminated with `dispatch returned 500` but the GH build is still running or finished. Wait for the GH run to finish, note the template name from its summary, then re-run Dapr with that name set — you get the promote step without paying for a second Packer build.
 
 ### HTTP API (server mode)
 

--- a/golden-image-workflow/activities/packer_build.go
+++ b/golden-image-workflow/activities/packer_build.go
@@ -61,21 +61,15 @@ func PackerBuildActivity(ctx workflow.ActivityContext) (any, error) {
 		inputs["dagger-version"] = input.DaggerVersion
 	}
 
-	dispatchTime := time.Now()
-	err := client.DispatchWorkflow(bgCtx, gh.DispatchWorkflowInput{
+	runID, err := client.DispatchAndFindRun(bgCtx, gh.DispatchWorkflowInput{
 		Owner:        input.Owner,
 		Repo:         input.Repo,
 		WorkflowFile: input.WorkflowFile,
 		Ref:          input.Ref,
 		Inputs:       inputs,
-	})
+	}, 2*time.Minute)
 	if err != nil {
 		return nil, fmt.Errorf("dispatch packer-build workflow: %w", err)
-	}
-
-	runID, err := client.FindRunByDispatch(bgCtx, input.Owner, input.Repo, input.WorkflowFile, dispatchTime, 10*time.Second, 2*time.Minute)
-	if err != nil {
-		return nil, fmt.Errorf("find packer-build run: %w", err)
 	}
 
 	result, err := client.WaitForCompletion(bgCtx, input.Owner, input.Repo, runID, 30*time.Second, 60*time.Minute)

--- a/golden-image-workflow/activities/promote.go
+++ b/golden-image-workflow/activities/promote.go
@@ -54,21 +54,15 @@ func PromoteActivity(ctx workflow.ActivityContext) (any, error) {
 		inputs["runner"] = input.Runner
 	}
 
-	dispatchTime := time.Now()
-	err := client.DispatchWorkflow(bgCtx, gh.DispatchWorkflowInput{
+	runID, err := client.DispatchAndFindRun(bgCtx, gh.DispatchWorkflowInput{
 		Owner:        input.Owner,
 		Repo:         input.Repo,
 		WorkflowFile: input.WorkflowFile,
 		Ref:          input.Ref,
 		Inputs:       inputs,
-	})
+	}, 2*time.Minute)
 	if err != nil {
 		return nil, fmt.Errorf("dispatch promote workflow: %w", err)
-	}
-
-	runID, err := client.FindRunByDispatch(bgCtx, input.Owner, input.Repo, input.WorkflowFile, dispatchTime, 10*time.Second, 2*time.Minute)
-	if err != nil {
-		return nil, fmt.Errorf("find promote run: %w", err)
 	}
 
 	result, err := client.WaitForCompletion(bgCtx, input.Owner, input.Repo, runID, 15*time.Second, 15*time.Minute)

--- a/golden-image-workflow/examples/inputs/vsphere-rocky9-labul.json
+++ b/golden-image-workflow/examples/inputs/vsphere-rocky9-labul.json
@@ -1,0 +1,26 @@
+{
+  "runID": "",
+  "environment": "labul",
+  "osProfile": "rocky9",
+  "osFamily": "rocky",
+  "provisioning": "base-os",
+  "branch": "main",
+  "github": {
+    "owner": "stuttgart-things",
+    "repo": "stuttgart-things",
+    "ref": "main"
+  },
+  "packer": {
+    "workflowFile": "dispatch-packer-build-dagger.yaml",
+    "packerVersion": "1.15.1",
+    "runner": "dagger-labul",
+    "daggerVersion": "0.20.6"
+  },
+  "promotion": {
+    "workflowFile": "dispatch-packer-movetemplate.yaml",
+    "targetName": "sthings-rocky9",
+    "buildFolder": "",
+    "goldenFolder": "",
+    "runner": "dagger-labul"
+  }
+}

--- a/golden-image-workflow/examples/inputs/vsphere-ubuntu26-labda-resume.json
+++ b/golden-image-workflow/examples/inputs/vsphere-ubuntu26-labda-resume.json
@@ -1,0 +1,27 @@
+{
+  "runID": "",
+  "environment": "labda",
+  "osProfile": "ubuntu26",
+  "osFamily": "ubuntu",
+  "provisioning": "base-os",
+  "branch": "main",
+  "existingTemplateName": "ubuntu26-base-os-20260423-1428",
+  "github": {
+    "owner": "stuttgart-things",
+    "repo": "stuttgart-things",
+    "ref": "main"
+  },
+  "packer": {
+    "workflowFile": "dispatch-packer-build-dagger.yaml",
+    "packerVersion": "1.15.1",
+    "runner": "dagger-labda",
+    "daggerVersion": "0.20.6"
+  },
+  "promotion": {
+    "workflowFile": "dispatch-packer-movetemplate.yaml",
+    "targetName": "sthings-u26",
+    "buildFolder": "",
+    "goldenFolder": "",
+    "runner": "dagger-labda"
+  }
+}

--- a/golden-image-workflow/examples/inputs/vsphere-ubuntu26-labda.json
+++ b/golden-image-workflow/examples/inputs/vsphere-ubuntu26-labda.json
@@ -1,0 +1,26 @@
+{
+  "runID": "",
+  "environment": "labda",
+  "osProfile": "ubuntu26",
+  "osFamily": "ubuntu",
+  "provisioning": "base-os",
+  "branch": "main",
+  "github": {
+    "owner": "stuttgart-things",
+    "repo": "stuttgart-things",
+    "ref": "main"
+  },
+  "packer": {
+    "workflowFile": "dispatch-packer-build-dagger.yaml",
+    "packerVersion": "1.15.1",
+    "runner": "dagger-labda",
+    "daggerVersion": "0.20.6"
+  },
+  "promotion": {
+    "workflowFile": "dispatch-packer-movetemplate.yaml",
+    "targetName": "sthings-u26",
+    "buildFolder": "",
+    "goldenFolder": "",
+    "runner": "dagger-labda"
+  }
+}

--- a/golden-image-workflow/github/client.go
+++ b/golden-image-workflow/github/client.go
@@ -44,7 +44,16 @@ type RunResult struct {
 	LogsURL    string `json:"logsUrl"`
 }
 
-// DispatchWorkflow triggers a workflow_dispatch event.
+// DispatchWorkflow triggers a workflow_dispatch event. Retries transient
+// 5xx and network errors up to 3 times with exponential backoff; 4xx
+// responses are returned immediately as they indicate a client error
+// (wrong ref, missing inputs, insufficient permissions).
+//
+// Note: GitHub's dispatch endpoint is not strictly transactional. A 5xx
+// response does not guarantee the run was not queued. Callers should
+// follow a failed dispatch with FindRunByDispatch using the pre-dispatch
+// timestamp to adopt any run GH may have created despite the error —
+// see DispatchAndFindRun for the combined flow.
 func (c *Client) DispatchWorkflow(ctx context.Context, input DispatchWorkflowInput) error {
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/workflows/%s/dispatches",
 		c.baseURL(), input.Owner, input.Repo, input.WorkflowFile)
@@ -59,24 +68,100 @@ func (c *Client) DispatchWorkflow(ctx context.Context, input DispatchWorkflowInp
 		return fmt.Errorf("marshal dispatch body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyJSON)))
-	if err != nil {
-		return fmt.Errorf("create dispatch request: %w", err)
-	}
-	c.setHeaders(req)
+	const maxAttempts = 3
+	backoff := 5 * time.Second
+	var lastErr error
 
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return fmt.Errorf("dispatch request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyJSON)))
+		if err != nil {
+			return fmt.Errorf("create dispatch request: %w", err)
+		}
+		c.setHeaders(req)
 
-	if resp.StatusCode != http.StatusNoContent {
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			// Network-level error; retry.
+			lastErr = fmt.Errorf("dispatch request failed (attempt %d/%d): %w", attempt, maxAttempts, err)
+			if attempt < maxAttempts {
+				if err := sleepCtx(ctx, backoff); err != nil {
+					return err
+				}
+				backoff *= 2
+				continue
+			}
+			return lastErr
+		}
+
+		if resp.StatusCode == http.StatusNoContent {
+			resp.Body.Close()
+			return nil
+		}
+
 		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		// Only retry server errors; client errors (4xx) won't resolve on retry.
+		if resp.StatusCode >= 500 && resp.StatusCode < 600 && attempt < maxAttempts {
+			lastErr = fmt.Errorf("dispatch returned %d (attempt %d/%d): %s", resp.StatusCode, attempt, maxAttempts, string(respBody))
+			if err := sleepCtx(ctx, backoff); err != nil {
+				return err
+			}
+			backoff *= 2
+			continue
+		}
+
 		return fmt.Errorf("dispatch returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	return nil
+	return lastErr
+}
+
+// DispatchAndFindRun dispatches a workflow and returns the resulting run ID.
+// On dispatch error (including 5xx after retries), it still attempts to
+// find a run that GH may have created despite the error response — this
+// recovers from GH's non-transactional dispatch behaviour that caused
+// silent orphan runs in the past.
+//
+// Returns the run ID on success, or an error if no run could be found
+// within findTimeout after the dispatch attempt started.
+func (c *Client) DispatchAndFindRun(ctx context.Context, input DispatchWorkflowInput, findTimeout time.Duration) (int64, error) {
+	dispatchTime := time.Now()
+	dispatchErr := c.DispatchWorkflow(ctx, input)
+
+	// Whether dispatch succeeded or failed, look for a run: GH sometimes
+	// creates the run even when the dispatch response is 5xx.
+	findPoll := 5 * time.Second
+	if dispatchErr != nil {
+		// If dispatch failed, give GH a bit more time in case it queued late.
+		findPoll = 10 * time.Second
+	}
+
+	runID, findErr := c.FindRunByDispatch(ctx, input.Owner, input.Repo, input.WorkflowFile, dispatchTime, findPoll, findTimeout)
+	if findErr == nil {
+		if dispatchErr != nil {
+			// Dispatch errored but a run exists — log and adopt.
+			fmt.Printf("adopted run %d despite dispatch error: %v\n", runID, dispatchErr)
+		}
+		return runID, nil
+	}
+
+	// No run found. Surface the original dispatch error if there was one,
+	// otherwise the find error.
+	if dispatchErr != nil {
+		return 0, fmt.Errorf("dispatch failed and no run was created: %w", dispatchErr)
+	}
+	return 0, findErr
+}
+
+// sleepCtx sleeps for d, but returns early if ctx is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
 }
 
 // workflowRun represents the relevant fields from the GH API runs response.

--- a/golden-image-workflow/main.go
+++ b/golden-image-workflow/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -20,6 +21,9 @@ func main() {
 	// Create workflow registry and register workflow + activities
 	r := workflow.NewRegistry()
 	if err := r.AddWorkflowN("GoldenImageBuildWorkflow", GoldenImageBuildWorkflow); err != nil {
+		log.Fatalf("failed to register workflow: %v", err)
+	}
+	if err := r.AddWorkflowN("VsphereTemplateWorkflow", VsphereTemplateWorkflow); err != nil {
 		log.Fatalf("failed to register workflow: %v", err)
 	}
 
@@ -57,20 +61,39 @@ func main() {
 	time.Sleep(2 * time.Second)
 	log.Println("workflow worker started")
 
-	// If --run flag is passed, start a workflow from JSON input file and exit
+	// If --run flag is passed, start a workflow from JSON input file and exit.
+	// Usage:
+	//   --run --input <file.json>                               (defaults to GoldenImageBuildWorkflow)
+	//   --run --workflow <Name> --input <file.json>
 	if len(os.Args) > 1 && os.Args[1] == "--run" {
 		inputFile := ""
-		if len(os.Args) > 3 && os.Args[2] == "--input" {
-			inputFile = os.Args[3]
-		} else if len(os.Args) > 2 {
-			inputFile = os.Args[2]
+		workflowName := "GoldenImageBuildWorkflow"
+		args := os.Args[2:]
+		for i := 0; i < len(args); i++ {
+			switch args[i] {
+			case "--input":
+				if i+1 < len(args) {
+					inputFile = args[i+1]
+					i++
+				}
+			case "--workflow":
+				if i+1 < len(args) {
+					workflowName = args[i+1]
+					i++
+				}
+			default:
+				// legacy positional form: --run <file.json>
+				if inputFile == "" {
+					inputFile = args[i]
+				}
+			}
 		}
 
 		if inputFile == "" {
-			log.Fatal("usage: golden-image-workflow --run --input <file.json>")
+			log.Fatal("usage: golden-image-workflow --run [--workflow <Name>] --input <file.json>")
 		}
 
-		if err := runWorkflowFromFile(ctx, wfClient, inputFile); err != nil {
+		if err := runWorkflowFromFile(ctx, wfClient, workflowName, inputFile); err != nil {
 			log.Fatalf("workflow failed: %v", err)
 		}
 		return
@@ -79,6 +102,7 @@ func main() {
 	// Otherwise, start HTTP server for API triggers
 	mux := http.NewServeMux()
 	mux.HandleFunc("/start", startWorkflowHandler)
+	mux.HandleFunc("/start-vsphere-template", startVsphereTemplateHandler)
 	mux.HandleFunc("/status/", statusWorkflowHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -102,39 +126,64 @@ func main() {
 	server.Shutdown(context.Background())
 }
 
-func runWorkflowFromFile(ctx context.Context, wfClient *workflow.Client, inputFile string) error {
+func runWorkflowFromFile(ctx context.Context, wfClient *workflow.Client, workflowName, inputFile string) error {
 	data, err := os.ReadFile(inputFile)
 	if err != nil {
 		return fmt.Errorf("read input file %s: %w", inputFile, err)
 	}
 
-	var input types.GoldenImageBuildInput
-	if err := json.Unmarshal(data, &input); err != nil {
-		return fmt.Errorf("parse input file: %w", err)
+	var (
+		inputPayload any
+		instanceID   string
+	)
+
+	switch workflowName {
+	case "GoldenImageBuildWorkflow":
+		var input types.GoldenImageBuildInput
+		if err := json.Unmarshal(data, &input); err != nil {
+			return fmt.Errorf("parse input file: %w", err)
+		}
+		if input.GitHub.Token == "" {
+			input.GitHub.Token = os.Getenv("GITHUB_TOKEN")
+		}
+		if input.GitHub.Token == "" {
+			return fmt.Errorf("no GitHub token: set 'github.token' in JSON or GITHUB_TOKEN env var")
+		}
+		instanceID = fmt.Sprintf("%s-%s-%d", input.Environment, input.OSProfile, time.Now().Unix())
+		if input.RunID != "" {
+			instanceID = input.RunID
+		}
+		inputPayload = input
+
+	case "VsphereTemplateWorkflow":
+		var input types.VsphereTemplateInput
+		if err := json.Unmarshal(data, &input); err != nil {
+			return fmt.Errorf("parse input file: %w", err)
+		}
+		if input.GitHub.Token == "" {
+			input.GitHub.Token = os.Getenv("GITHUB_TOKEN")
+		}
+		if input.GitHub.Token == "" {
+			return fmt.Errorf("no GitHub token: set 'github.token' in JSON or GITHUB_TOKEN env var")
+		}
+		instanceID = fmt.Sprintf("vsphere-%s-%s-%d", input.Environment, input.OSProfile, time.Now().Unix())
+		if input.RunID != "" {
+			instanceID = input.RunID
+		}
+		inputPayload = input
+
+	default:
+		return fmt.Errorf("unknown workflow name: %s", workflowName)
 	}
 
-	// Allow GITHUB_TOKEN from env to override empty token in JSON
-	if input.GitHub.Token == "" {
-		input.GitHub.Token = os.Getenv("GITHUB_TOKEN")
-	}
-
-	if input.GitHub.Token == "" {
-		return fmt.Errorf("no GitHub token: set 'github.token' in JSON or GITHUB_TOKEN env var")
-	}
-
-	instanceID := fmt.Sprintf("%s-%s-%d", input.Environment, input.OSProfile, time.Now().Unix())
-	if input.RunID != "" {
-		instanceID = input.RunID
-	}
-
-	id, err := wfClient.ScheduleWorkflow(ctx, "GoldenImageBuildWorkflow",
+	id, err := wfClient.ScheduleWorkflow(ctx, workflowName,
 		workflow.WithInstanceID(instanceID),
-		workflow.WithInput(input),
+		workflow.WithInput(inputPayload),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to schedule workflow: %w", err)
 	}
-	log.Printf("workflow started: instanceID=%s", id)
+	log.Printf("workflow started: name=%s instanceID=%s", workflowName, id)
 
 	// Wait for completion
 	meta, err := wfClient.WaitForWorkflowCompletion(ctx, id)
@@ -149,13 +198,12 @@ func runWorkflowFromFile(ctx context.Context, wfClient *workflow.Client, inputFi
 	}
 
 	if meta.Output != nil {
-		var output types.GoldenImageBuildOutput
-		if err := json.Unmarshal([]byte(meta.Output.GetValue()), &output); err != nil {
-			log.Printf("could not deserialize output: %v", err)
-			log.Printf("raw output: %s", meta.Output.GetValue())
+		raw := meta.Output.GetValue()
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, []byte(raw), "", "  "); err == nil {
+			log.Printf("workflow output:\n%s", pretty.String())
 		} else {
-			result, _ := json.MarshalIndent(output, "", "  ")
-			log.Printf("workflow output:\n%s", string(result))
+			log.Printf("raw output: %s", raw)
 		}
 	}
 
@@ -195,9 +243,9 @@ func statusWorkflowHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if meta.Output != nil {
-		var output types.GoldenImageBuildOutput
-		if err := json.Unmarshal([]byte(meta.Output.GetValue()), &output); err == nil {
-			response["output"] = output
+		var out json.RawMessage
+		if err := json.Unmarshal([]byte(meta.Output.GetValue()), &out); err == nil {
+			response["output"] = out
 		}
 	}
 
@@ -210,6 +258,49 @@ func statusWorkflowHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
+}
+
+func startVsphereTemplateHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var input types.VsphereTemplateInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, fmt.Sprintf("invalid input: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if input.GitHub.Token == "" {
+		input.GitHub.Token = os.Getenv("GITHUB_TOKEN")
+	}
+
+	wfClient, err := dapr.NewWorkflowClient()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("workflow client error: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	instanceID := fmt.Sprintf("vsphere-%s-%s-%d", input.Environment, input.OSProfile, time.Now().Unix())
+	if input.RunID != "" {
+		instanceID = input.RunID
+	}
+
+	id, err := wfClient.ScheduleWorkflow(r.Context(), "VsphereTemplateWorkflow",
+		workflow.WithInstanceID(instanceID),
+		workflow.WithInput(input),
+	)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to start workflow: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"instanceID": id,
+		"status":     "started",
+	})
 }
 
 func startWorkflowHandler(w http.ResponseWriter, r *http.Request) {

--- a/golden-image-workflow/types/vsphere_template.go
+++ b/golden-image-workflow/types/vsphere_template.go
@@ -1,0 +1,54 @@
+package types
+
+// VsphereTemplateInput is the input to VsphereTemplateWorkflow — a minimal
+// pipeline that builds a Packer vSphere template and promotes it to a
+// golden image folder. Assumes the Packer config already exists on the
+// target branch (no render/commit step).
+type VsphereTemplateInput struct {
+	RunID        string              `json:"runID"`
+	Environment  string              `json:"environment"`  // "labul" | "labda"
+	OSProfile    string              `json:"osProfile"`    // "ubuntu24" | "ubuntu26" | "rocky9" ...
+	OSFamily     string              `json:"osFamily"`     // "ubuntu" | "rocky"
+	Provisioning string              `json:"provisioning"` // "base-os" | "rke2-node"
+	Branch       string              `json:"branch"`       // branch holding the packer build dir; defaults to "main"
+	// ExistingTemplateName skips the Packer build step and promotes an
+	// already-built template. Use this to recover when a previous run
+	// orphaned a GH Actions build (e.g. Dapr crashed or GH dispatch 5xx'd
+	// after queuing). Set to the timestamped Packer artifact name
+	// (e.g. "ubuntu26-base-os-20260423-1428") and the workflow jumps
+	// straight to the promote step.
+	ExistingTemplateName string              `json:"existingTemplateName,omitempty"`
+	GitHub               GitHubConfig        `json:"github"`
+	Packer               VspherePackerRef    `json:"packer"`
+	Promotion            VspherePromotionRef `json:"promotion"`
+}
+
+type VspherePackerRef struct {
+	WorkflowFile  string `json:"workflowFile"` // e.g. "dispatch-packer-build-dagger.yaml"
+	PackerVersion string `json:"packerVersion"`
+	Runner        string `json:"runner"`
+	DaggerVersion string `json:"daggerVersion"`
+}
+
+type VspherePromotionRef struct {
+	WorkflowFile string `json:"workflowFile"` // e.g. "dispatch-packer-movetemplate.yaml"
+	TargetName   string `json:"targetName"`   // required: golden image name, e.g. "sthings-u26"
+	BuildFolder  string `json:"buildFolder"`  // optional override; empty → GH workflow derives from lab
+	GoldenFolder string `json:"goldenFolder"` // optional override; empty → GH workflow derives from lab
+	Runner       string `json:"runner"`
+}
+
+type VsphereTemplateOutput struct {
+	RunID              string                  `json:"runID"`
+	Status             string                  `json:"status"` // "running" | "success" | "failed"
+	TemplateName       string                  `json:"templateName"`       // from packer build step
+	GoldenTemplateName string                  `json:"goldenTemplateName"` // == promotion.targetName on success
+	FailedStep         string                  `json:"failedStep,omitempty"`
+	Error              string                  `json:"error,omitempty"`
+	StepRunURLs        VsphereTemplateStepURLs `json:"stepRunUrls"`
+}
+
+type VsphereTemplateStepURLs struct {
+	PackerBuild string `json:"packerBuild,omitempty"`
+	Promote     string `json:"promote,omitempty"`
+}

--- a/golden-image-workflow/workflow_vsphere_template.go
+++ b/golden-image-workflow/workflow_vsphere_template.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dapr/durabletask-go/workflow"
+	"github.com/stuttgart-things/dapr-workflows/golden-image-workflow/activities"
+	"github.com/stuttgart-things/dapr-workflows/golden-image-workflow/types"
+)
+
+// VsphereTemplateWorkflow dispatches a Packer build GH Actions workflow,
+// captures the resulting template name, then dispatches the promote
+// (rename/delete/move) workflow with that name as input.
+//
+// If input.ExistingTemplateName is set, the Packer build step is skipped
+// and the workflow promotes the given template. Use this to recover from
+// orphaned GH runs where a previous workflow failed after dispatching
+// (e.g. GH dispatch returned 5xx after queuing, or the worker crashed).
+func VsphereTemplateWorkflow(ctx *workflow.WorkflowContext) (any, error) {
+	var input types.VsphereTemplateInput
+	if err := ctx.GetInput(&input); err != nil {
+		return nil, fmt.Errorf("failed to get workflow input: %w", err)
+	}
+
+	branch := input.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	output := types.VsphereTemplateOutput{
+		RunID:  input.RunID,
+		Status: "running",
+	}
+
+	gh := input.GitHub
+
+	// Step 1: Packer build (unless we're adopting an existing template).
+	var templateName string
+	if input.ExistingTemplateName != "" {
+		fmt.Printf("resume mode: skipping packer build, promoting existing template %q\n", input.ExistingTemplateName)
+		templateName = input.ExistingTemplateName
+		output.TemplateName = templateName
+	} else {
+		packerInput := activities.PackerBuildInput{
+			Owner:         gh.Owner,
+			Repo:          gh.Repo,
+			Ref:           gh.Ref,
+			Token:         gh.Token,
+			WorkflowFile:  input.Packer.WorkflowFile,
+			OSVersion:     input.OSProfile,
+			Lab:           input.Environment,
+			OSFamily:      input.OSFamily,
+			Provisioning:  input.Provisioning,
+			Branch:        branch,
+			PackerVersion: input.Packer.PackerVersion,
+			Runner:        input.Packer.Runner,
+			DaggerVersion: input.Packer.DaggerVersion,
+		}
+
+		// Activity retry guards worker-level blips. MaxAttempts=2 so we don't
+		// redundantly kick off a second long-running packer build unless the
+		// first attempt failed before any real work — the activity's internal
+		// dispatch-with-recovery is the primary defense.
+		packerRetry := &workflow.RetryPolicy{
+			MaxAttempts:          2,
+			InitialRetryInterval: 30 * time.Second,
+			BackoffCoefficient:   2.0,
+			MaxRetryInterval:     2 * time.Minute,
+			RetryTimeout:         5 * time.Minute,
+		}
+
+		var packerOutput activities.PackerBuildOutput
+		if err := ctx.CallActivity(activities.PackerBuildActivity,
+			workflow.WithActivityInput(packerInput),
+			workflow.WithActivityRetryPolicy(packerRetry),
+		).Await(&packerOutput); err != nil {
+			output.Status = "failed"
+			output.FailedStep = "PackerBuild"
+			output.Error = err.Error()
+			output.StepRunURLs.PackerBuild = packerOutput.RunURL
+			return &output, err
+		}
+		output.StepRunURLs.PackerBuild = packerOutput.RunURL
+		output.TemplateName = packerOutput.TemplateName
+		fmt.Printf("packer build completed: %s\n", packerOutput.Message)
+
+		if packerOutput.TemplateName == "" {
+			output.Status = "failed"
+			output.FailedStep = "PackerBuild"
+			output.Error = "template name not found in packer build log"
+			return &output, fmt.Errorf("template name not found in packer build log")
+		}
+		templateName = packerOutput.TemplateName
+	}
+
+	// Step 2: Promote (rename → delete existing → move).
+	// Promote is short-running and safe to retry on transient errors.
+	promoteInput := activities.PromoteInput{
+		Owner:        gh.Owner,
+		Repo:         gh.Repo,
+		Ref:          gh.Ref,
+		Token:        gh.Token,
+		WorkflowFile: input.Promotion.WorkflowFile,
+		TemplateName: templateName,
+		TargetName:   input.Promotion.TargetName,
+		BuildFolder:  input.Promotion.BuildFolder,
+		GoldenFolder: input.Promotion.GoldenFolder,
+		Runner:       input.Promotion.Runner,
+	}
+
+	promoteRetry := &workflow.RetryPolicy{
+		MaxAttempts:          3,
+		InitialRetryInterval: 10 * time.Second,
+		BackoffCoefficient:   2.0,
+		MaxRetryInterval:     60 * time.Second,
+		RetryTimeout:         10 * time.Minute,
+	}
+
+	var promoteOutput activities.PromoteOutput
+	if err := ctx.CallActivity(activities.PromoteActivity,
+		workflow.WithActivityInput(promoteInput),
+		workflow.WithActivityRetryPolicy(promoteRetry),
+	).Await(&promoteOutput); err != nil {
+		output.Status = "failed"
+		output.FailedStep = "Promote"
+		output.Error = err.Error()
+		output.StepRunURLs.Promote = promoteOutput.RunURL
+		return &output, err
+	}
+	output.StepRunURLs.Promote = promoteOutput.RunURL
+	output.GoldenTemplateName = input.Promotion.TargetName
+	output.Status = "success"
+	fmt.Printf("promotion completed: %s\n", promoteOutput.Message)
+
+	return &output, nil
+}


### PR DESCRIPTION
## Summary

- Adds `VsphereTemplateWorkflow` — a lean two-step Dapr workflow (Packer build → promote to golden folder) that runs alongside the existing `GoldenImageBuildWorkflow` without touching it
- Hardens GitHub dispatch against GH's non-transactional `workflow_dispatch` endpoint: retries transient 5xx, polls for adoption after errors, and applies per-step retry policies
- Adds a manual resume mode (`existingTemplateName`) so an orphaned GH run from a previous Dapr failure can be promoted without paying for a second Packer build

## Why

Last run hit two concrete bugs:

1. `GoldenImageBuildWorkflow`'s render/test/notify steps were too much for the common case where a Packer build config is already committed and we just want to build + promote.
2. `DispatchWorkflow` treated any non-204 response as a hard failure. GH returned `HTTP 500` after queuing the Packer run; Dapr terminated FAILED, GH kept running the orphaned build, and there was no way to reuse it.

Fix #1 is addressed by the new lean workflow. Fix #2 is addressed by three layered safety nets below.

## What's new

### New workflow: `VsphereTemplateWorkflow`

Two activities, no render/test/notify noise, OS-agnostic but vSphere-scoped (supports ubuntu24/ubuntu26/rocky9/…).

Selected at runtime:

```bash
./golden-image-workflow --run --workflow VsphereTemplateWorkflow \
  --input examples/inputs/vsphere-ubuntu26-labda.json
```

The ephemeral Packer template name (e.g. `ubuntu26-base-os-20260423-1428`) is scraped from the build run's logs by `ExtractFromLog` and passed to the promote step as `template-name` — callers only supply the **target** golden name (`sthings-u26`).

### Resilience (three safety nets)

1. **Dispatch retry.** `DispatchWorkflow` retries transient network errors and HTTP 5xx up to 3× with exponential backoff (5s → 10s → 20s). 4xx fails fast.
2. **Dispatch adoption.** `DispatchAndFindRun` *always* polls for a recently-created run after dispatching — even when dispatch errored — because GH's dispatch is not strictly transactional. Logs `adopted run N despite dispatch error` when that happens. Packer and promote activities migrated to this API.
3. **Activity retry policies.** Packer: 2 attempts / 5m total. Promote: 3 attempts / 10m total.

### Manual resume mode

Set `existingTemplateName` in the input JSON to skip the Packer build and promote an already-built template. Example input included: `vsphere-ubuntu26-labda-resume.json`.

### `main.go` changes

- Registers the new workflow
- Extends `--run` with `--workflow <Name>` (backward-compatible — default stays `GoldenImageBuildWorkflow`)
- New HTTP endpoint `/start-vsphere-template`
- Status handler switches to raw output passthrough so it works for any workflow type

## Not in this PR (explicitly deferred)

- Migrating `render.go`, `test_vm.go`, `notify.go`, `commit_pr.go` to `DispatchAndFindRun` (same bug class applies, but only the full `GoldenImageBuildWorkflow` hits those)
- Binary rename to `golden-vmtemplate-workflow`

## Test plan

- [ ] `go build ./...` and `go vet ./...` — both green locally
- [ ] `dapr run --app-id golden-image -- ./golden-image-workflow --run --workflow VsphereTemplateWorkflow --input examples/inputs/vsphere-ubuntu26-labda.json` triggers build + promote end-to-end
- [ ] Resume path: re-run with `vsphere-ubuntu26-labda-resume.json` and verify build is skipped (log: `resume mode: skipping packer build, promoting existing template ...`)
- [ ] Existing `GoldenImageBuildWorkflow` still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)