### PR TITLE
fix(promote): thread lab input to dispatch-packer-movetemplate

### DIFF
--- a/golden-image-workflow/README.md
+++ b/golden-image-workflow/README.md
@@ -219,6 +219,9 @@ The Dapr workflow dispatches these GH Actions workflows in the target repo. Exam
 | `dispatch-render-packer-config.yaml` | Render packer config, commit to branch, create PR | Already exists in stuttgart-things |
 | `dispatch-packer-build-dagger.yaml` | Run Packer build via Dagger | [examples/dispatch-packer-build-dagger.yaml](examples/dispatch-packer-build-dagger.yaml) |
 | `dispatch-packer-testvm-dagger.yaml` | Create test VM and validate | Already exists in stuttgart-things |
+| `dispatch-packer-movetemplate.yaml` | Rename built template → delete any pre-existing golden → move into the golden folder | Already exists in stuttgart-things |
+
+`PromoteActivity` dispatches `dispatch-packer-movetemplate.yaml` with `template-name`, `target-name`, `lab` (required — selects the vSphere build/golden folders), and optionally `build-folder`/`golden-folder`/`runner`. The `lab` input is threaded through from `input.Environment` in both `VsphereTemplateWorkflow` and `GoldenImageBuildWorkflow`; the GH workflow's `Resolve vSphere folders` step exits 1 if it's missing.
 
 ## Project Structure
 

--- a/golden-image-workflow/activities/promote.go
+++ b/golden-image-workflow/activities/promote.go
@@ -17,6 +17,7 @@ type PromoteInput struct {
 	WorkflowFile string `json:"workflowFile"`
 	TemplateName string `json:"templateName"` // source template from packer build
 	TargetName   string `json:"targetName"`   // golden image name
+	Lab          string `json:"lab"`          // labul | labda — selects vSphere defaults
 	BuildFolder  string `json:"buildFolder"`  // vSphere packer build folder
 	GoldenFolder string `json:"goldenFolder"` // vSphere golden image folder
 	Runner       string `json:"runner"`
@@ -44,6 +45,9 @@ func PromoteActivity(ctx workflow.ActivityContext) (any, error) {
 		"target-name":   input.TargetName,
 	}
 
+	if input.Lab != "" {
+		inputs["lab"] = input.Lab
+	}
 	if input.BuildFolder != "" {
 		inputs["build-folder"] = input.BuildFolder
 	}

--- a/golden-image-workflow/workflow.go
+++ b/golden-image-workflow/workflow.go
@@ -127,6 +127,7 @@ func GoldenImageBuildWorkflow(ctx *workflow.WorkflowContext) (any, error) {
 			WorkflowFile: input.Promotion.WorkflowFile,
 			TemplateName: packerOutput.TemplateName,
 			TargetName:   input.Promotion.TargetName,
+			Lab:          input.Environment,
 			BuildFolder:  input.Promotion.BuildFolder,
 			GoldenFolder: input.Promotion.GoldenFolder,
 			Runner:       input.Promotion.Runner,

--- a/golden-image-workflow/workflow_vsphere_template.go
+++ b/golden-image-workflow/workflow_vsphere_template.go
@@ -104,6 +104,7 @@ func VsphereTemplateWorkflow(ctx *workflow.WorkflowContext) (any, error) {
 		WorkflowFile: input.Promotion.WorkflowFile,
 		TemplateName: templateName,
 		TargetName:   input.Promotion.TargetName,
+		Lab:          input.Environment,
 		BuildFolder:  input.Promotion.BuildFolder,
 		GoldenFolder: input.Promotion.GoldenFolder,
 		Runner:       input.Promotion.Runner,


### PR DESCRIPTION
## Summary
- `dispatch-packer-movetemplate.yaml` requires a `lab` input (labul | labda) to resolve default vSphere build/golden folders. `PromoteActivity` wasn't passing it, so the GH workflow's `Resolve vSphere folders` step errored with `Unknown lab:` and the whole promote failed (visible in earlier Dapr runs as `promote workflow concluded with: failure`).
- Adds `Lab` to `PromoteInput` and threads `input.Environment` through both `VsphereTemplateWorkflow` and `GoldenImageBuildWorkflow`.
- Documents `dispatch-packer-movetemplate.yaml` and the `lab` contract in the README.

## Test plan
- [x] `go build ./...` / `go vet ./...` pass.
- [x] End-to-end move-template dispatch with `lab=labda` succeeds: https://github.com/stuttgart-things/stuttgart-things/actions/runs/24852801756
- [ ] Run full `VsphereTemplateWorkflow` via Dapr and confirm promote step completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)